### PR TITLE
Update jinja link in documentation

### DIFF
--- a/flask_website/templates/general/index.html
+++ b/flask_website/templates/general/index.html
@@ -77,7 +77,7 @@ def hello():
       page='testing') }}">unit testing support</a>
     <li>RESTful <a href="{{ url_for('docs.show', page='quickstart')
       }}#routing">request dispatching</a>
-    <li>uses <a href=http://jinja.pocoo.org/2/documentation/templates>Jinja2 templating</a>
+    <li>uses <a href=http://jinja.pocoo.org/docs/templates/>Jinja2 templating</a>
     <li>support for <a href="{{ url_for('docs.show', page='quickstart')
       }}#sessions">secure cookies</a> (client side sessions)
     <li>100% <a href=http://www.python.org/dev/peps/pep-0333/>WSGI 1.0</a> compliant


### PR DESCRIPTION
The old link points to a 404 page. Fixes https://github.com/mitsuhiko/flask/issues/1037
