### PR TITLE
Added Flask-Via to Extension Registry

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -535,6 +535,16 @@ extensions = [
         github='singingwolfboy/flask-misaka',
         approved=True,
     ),
+    Extension('Flask-Via', 'SOON_, Chris Reeves',
+        description='''
+            <p>
+                Provides a clean, simple URL routing framework for growing Flask 
+                Applications.
+        ''',
+        docs='http://flask-via.soon.build',
+        github='thisissoon/Flask-Via',
+        approved=True,
+    ),
 ]
 
 


### PR DESCRIPTION
Flask-Via adds a routing Framework similar to Django URLs. Routes are loaded when the app starts, this allows developers to define routes in a `routes.py` it can also include other routes from other python modules, create blueprints etc.

It would be great if it could be added to the Flask Extension Registry.

Thanks,

Chris
