### PR TITLE
Add Flask-Limiter to extensions listing

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -535,6 +535,16 @@ extensions = [
         github='singingwolfboy/flask-misaka',
         approved=True,
     ),
+    Extension('Flask-Limiter', 'Ali-Akber Saifee',
+              description='''
+            <p>Adds Ratelimiting support to Flask.
+            Supports a configurable storage backend with implementations for
+            in-memory, redis and memcache.
+        ''',
+        github='alisaifee/flask-limiter',
+        docs='http://flask-limiter.readthedocs.org/en/latest/',
+        approved=False,
+    ),
 ]
 
 


### PR DESCRIPTION
The extension allows for adding rate limiting to routes in flask. Different rate limiting strategies can be configured and the actual storage of rate limit values can be configured to use one of in-memory, redis or memcache.

I've left it `approved=False`, however I've followed the guidelines and some of the artifacts for consideration are:
- [documentation](http://flask-limiter.readthedocs.org)
- [package](https://pypi.python.org/pypi/Flask-Limiter)
- [repository](http://github.com/alisaifee/flask-limiter)
- [tests](https://travis-ci.org/alisaifee/flask-limiter/builds/27474700) / [coverage](https://coveralls.io/r/alisaifee/flask-limiter?branch=master)
