### PR TITLE
Add Flask-QueryInspect extension

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -645,6 +645,16 @@ unlisted = [
             Unlisted because duplicates the Flask-SeaSurf extension.
         '''
     ),
+    Extension('Flask-QueryInspect', 'Bret Barker',
+        description='''
+            <p>Provides metrics on SQL queries (using SQLAlchemy) executed
+             for each request.</p>
+        ''',
+        docs='https://github.com/noise/flask-queryinspect',
+        github='https://github.com/noise/flask-queryinspect',
+        notes='''
+        '''
+    ),
 ]
 
 


### PR DESCRIPTION
I'm requesting that my extension Flask-QueryInspect be added to the approved list.

Flask-QueryInspect is a Flask extension that provides metrics on SQL queries executed for each request. It assumes use of and relies upon SQLAlchemy as the underlying ORM.

I believe I've met all of the requirements from http://flask.pocoo.org/docs/extensiondev/#approved-extensions
- Docs: https://github.com/noise/flask-queryinspect
- PyPI: https://pypi.python.org/pypi/Flask-QueryInspect
- Tests: https://travis-ci.org/noise/flask-queryinspect

Please let me know if there is anything else required.
