### PR TITLE
Remove links to moribund feedback website

### DIFF
--- a/flask_website/listings/projects.py
+++ b/flask_website/listings/projects.py
@@ -130,11 +130,6 @@ projects = {
             <p>
               A collection of responsive web designs.
         '''),
-        Project('Flask Feedback', 'http://feedback.flask.pocoo.org/', u'''
-            <p>
-              Website by the Flask project that collects feedback from
-              users.
-        ''', source='https://github.com/mitsuhiko/flask-feedback'),
         Project('pizje.ns-keip', 'http://pizje.ns-keip.ru/', u'''
             <p>
               Russian game website.

--- a/flask_website/templates/community/index.html
+++ b/flask_website/templates/community/index.html
@@ -5,10 +5,7 @@
     community evolved around it.  There is an active
     <a href="{{ url_for('mailinglist.index') }}">mailinglist</a> both for
     developers using Flask as well as working on the core, and an
-    <a href="{{ url_for('community.irc') }}">IRC</a> channel.  Also consider
-    visiting the <a href="http://feedback.flask.pocoo.org/">feedback</a>
-    website and dropping us some messages there if you are happy or
-    unhappy with Flask to help us improve.
+    <a href="{{ url_for('community.irc') }}">IRC</a> channel.
   <p>
     If you want to spread the word, there is also a selection of
     <a href="{{ url_for('community.badges') }}">badges</a> and

--- a/flask_website/templates/general/index.html
+++ b/flask_website/templates/general/index.html
@@ -102,7 +102,7 @@ def hello():
     create a new ticket or fork.  If you just want to chat with fellow
     developers, visit <a href="{{ url_for('community.irc') }}">the IRC
     channel</a> or join <a href="{{ url_for('mailinglist.index') }}"
-    >the mailinglist</a>. You can also directly add issues and feature
+    >the mailinglist</a>.  You can also directly add issues and feature
     requests to the <a href="http://github.com/mitsuhiko/flask/issues">
     issue tracker</a>.
   {% if tweets %}

--- a/flask_website/templates/general/index.html
+++ b/flask_website/templates/general/index.html
@@ -102,9 +102,7 @@ def hello():
     create a new ticket or fork.  If you just want to chat with fellow
     developers, visit <a href="{{ url_for('community.irc') }}">the IRC
     channel</a> or join <a href="{{ url_for('mailinglist.index') }}"
-    >the mailinglist</a>.  Also as a simple method to help us improve
-    the framework, visit the <a href=http://feedback.flask.pocoo.org/
-    >feedback website</a>.  You can also directly add issues and feature
+    >the mailinglist</a>. You can also directly add issues and feature
     requests to the <a href="http://github.com/mitsuhiko/flask/issues">
     issue tracker</a>.
   {% if tweets %}


### PR DESCRIPTION
http://feedback.flask.pocoo.org/ appears to me to be offline. I get a weird redirect to Adobe, or a Verizon MITM search page (so it's possible that the feedback site is still live, and I'm not seeing it due to some intervening network misconfiguration):

![screen shot 2015-10-30 at 2 29 49 pm](https://cloud.githubusercontent.com/assets/134455/10854541/b9394e64-7f12-11e5-9972-e4908f02d873.png)

![screen shot 2015-10-30 at 2 30 20 pm](https://cloud.githubusercontent.com/assets/134455/10854548/c60b5ff6-7f12-11e5-8cc1-6bce91ed76df.png)
