### PR TITLE
fix documentation link for flask-ask extension

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -644,7 +644,7 @@ extensions = [
               Flask-Ask makes it easy to write Amazon Echo apps with Flask and
               the Alexa Skills Kit.
         ''',
-        docs='http://flask-ask.readthedocs.io/en/latest/',
+        docs='https://johnwheeler.org/flask-ask/',
         github='johnwheeler/flask-ask'
     ),
 ]


### PR DESCRIPTION
new primary documentation home for flask-ask extension (johnwheeler.org). 
