### PR TITLE
Add Flask-REST-JSONAPI to extensions

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -647,11 +647,12 @@ extensions = [
         docs='http://flask-ask.readthedocs.io/en/latest/',
         github='johnwheeler/flask-ask'
     ),
-    Extension('Flask-Rest-JSONAPI', 'Pierre CHAISY',
+    Extension('Flask-Rest-JSONAPI', 'Pierre Chaisy',
         description='''
             <p>
-              Flash extension to build REST APIs around JSONAPI 1.0 specification
-              with a powerful data layer system.
+              Build REST APIs following the
+              <a href="http://jsonapi.org/format/">JSONAPI</a>
+              specification with a powerful data layer system.
         ''',
         docs='http://flask-rest-jsonapi.readthedocs.io/en/latest/',
         github='miLibris/flask-rest-jsonapi'

--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -647,6 +647,15 @@ extensions = [
         docs='http://flask-ask.readthedocs.io/en/latest/',
         github='johnwheeler/flask-ask'
     ),
+    Extension('Flask-Rest-JSONAPI', 'Pierre CHAISY',
+        description='''
+            <p>
+              Flash extension to build REST APIs around JSONAPI 1.0 specification
+              with a powerful data layer system.
+        ''',
+        docs='http://flask-rest-jsonapi.readthedocs.io/en/latest/',
+        github='miLibris/flask-rest-jsonapi'
+    ),
 ]
 
 


### PR DESCRIPTION
Flask-REST-JSONAPI is an implementation of jsonapi reference http://jsonapi.org around flask and marshmallow. It combines a strong specification about client server interactions (jsonapi reference) and a powerfull library that helps you to quickly create rest api with hudge flexibility. You can use any data provider like SQLAlchemy or MongoDB (already available) or create your own data layer without to make pull request.