### PR TITLE
Updated Documention Link for Flask-User

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -627,7 +627,7 @@ extensions = [
             Role-based Authorization and Internationalization.
         ''',
         github='lingthio/flask-user',
-        docs='http://pythonhosted.org/Flask-User/',
+        docs='http://flask-user.readthedocs.io/',
         approved=True,
     ),
     Extension('Flask-Via', 'SOON_, Chris Reeves',


### PR DESCRIPTION
Docs now hosted at http://flask-user.readthedocs.io/ per GitHub ReadMe