### PR TITLE
Remove Flask-OAuth website from extensions list

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -37,16 +37,6 @@ class Extension(object):
 # This list contains all extensions that were approved as well as those which
 # passed listing.
 extensions = [
-    Extension('Flask-OAuth', 'Armin Ronacher',
-        description='''
-            <p>Adds <a href="http://oauth.net/">OAuth</a> support to Flask.
-        ''',
-        github='mitsuhiko/flask-oauth',
-        docs='http://pythonhosted.org/Flask-OAuth/',
-        notes='''
-            Short long description, missing tests.
-        '''
-    ),
     Extension('Flask-OpenID', 'Armin Ronacher',
         description='''
             <p>Adds <a href="http://openid.net/">OpenID</a> support to Flask.


### PR DESCRIPTION
Since it is marked as unmaintained: https://github.com/mitsuhiko/flask-oauth/pull/94