### PR TITLE
Drop Python 2.5 and 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 
 python:
-  - 2.5
-  - 2.6
   - 2.7
   - pypy
 


### PR DESCRIPTION
Just remove 2.5 and 2.6 in `.travis.yml`.