### PR TITLE
Fix import error when install distribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 
 before_install: pip install simplejson
 
+before_script: easy_install distribute
+  
 script: python setup.py test
 
 branches:


### PR DESCRIPTION
Error traceback:
```pytb
Collecting distribute (from -r requirements.txt (line 11))
  Downloading https://files.pythonhosted.org/packages/5f/ad/1fde06877a8d7d5c9b60eff7de2d452f639916ae1d48f0b8f97bf97e570a/distribute-0.7.3.zip (145kB)
    100% |████████████████████████████████| 153kB 9.0MB/s 
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/distribute.egg-info
    writing requirements to pip-egg-info/distribute.egg-info/requires.txt
    writing pip-egg-info/distribute.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/distribute.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/distribute.egg-info/dependency_links.txt
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-KsAMCS/distribute/setup.py", line 58, in <module>
        setuptools.setup(**setup_params)
      File "/opt/python/2.7.14/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/opt/python/2.7.14/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/opt/python/2.7.14/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "setuptools/command/egg_info.py", line 177, in run
        writer = ep.load(installer=installer)
      File "pkg_resources.py", line 2241, in load
        if require: self.require(env, installer)
      File "pkg_resources.py", line 2254, in require
        working_set.resolve(self.dist.requires(self.extras),env,installer)))
      File "pkg_resources.py", line 2471, in requires
        dm = self._dep_map
      File "pkg_resources.py", line 2682, in _dep_map
        self.__dep_map = self._compute_dependencies()
      File "pkg_resources.py", line 2699, in _compute_dependencies
        from _markerlib import compile as compile_marker
    ImportError: No module named _markerlib 
```