### PR TITLE
fixed a few broken links

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -494,7 +494,7 @@ extensions = [
             <p>
               A full-text search engine using Pony ORM and Whoosh.
         ''',
-        docs='http://pythonhosted.org/flask-ponywhoosh/',
+        docs='https://pythonhosted.org/Flask-PonyWhoosh/',
         github='compiteing/flask-ponywhoosh',
     ),
     Extension('Flask-PyMongo', 'Dan Crosta',

--- a/flask_website/templates/community/irc.html
+++ b/flask_website/templates/community/irc.html
@@ -22,5 +22,5 @@
     #pocoo in your browser</a>.
   <p>
     If you want to read up on older discussions you can access
-    the IRC logs on <a href=https://botbot.me/freenode/pocoo/>https://botbot.me/freenode/pocoo/</a>.
+    the IRC logs on <a href="https://web.archive.org/web/20181102190236/https://botbot.me/freenode/pocoo/">https://botbot.me/freenode/pocoo/</a> (note: archive.org link).
 {% endblock %}

--- a/flask_website/templates/community/logos.html
+++ b/flask_website/templates/community/logos.html
@@ -19,8 +19,6 @@
     <li>{{ logo('pdf') }}: for print use
   </ul>
   <p>
-    The font used in the logo is “Hightower Text roman” from the
-    Font Bureau foundry.  The font can be purchased from
-    <a href="http://www.ascenderfonts.com/font/hightower-text-roman.aspx"
-    >Ascender Fonts</a>.
+    The font used in the logo is “<a href="https://en.wikipedia.org/wiki/Hightower_Text">Hightower
+    Text roman</a>” from the Font Bureau foundry.
 {% endblock %}


### PR DESCRIPTION
Some link cleanup.

1. Removed dead link (http://www.ascenderfonts.com/font/hightower-text-roman.aspx) to hightower font. The font appears to be no longer available on the acenderfonts.com website. The link is refereced here: http://flask.pocoo.org/community/logos/
2. Updated Flask-PonyWhoosh link, which linked to an apparent case-sensitive 404.  Link was: http://pythonhosted.org/flask-ponywhoosh/, updated link is: https://pythonhosted.org/Flask-PonyWhoosh/
3. Replaced dead https://botbot.me/freenode/pocoo/ link with Wayback Machine link. botbot.me was shut down November 2018.
