### PR TITLE
Add Flask Dramatiq extension to registry

### DIFF
--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -7,12 +7,13 @@ from flask import Markup
 class Extension(object):
 
     def __init__(self, name, author, description,
-                 github=None, bitbucket=None, docs=None, website=None,
+                 github=None, gitlab=None, bitbucket=None, docs=None, website=None,
                  approved=False, notes=None):
         self.name = name
         self.author = author
         self.description = Markup(description)
         self.github = github
+        self.gitlab = gitlab
         self.bitbucket = bitbucket
         self.docs = docs
         self.website = website

--- a/flask_website/listings/extensions.py
+++ b/flask_website/listings/extensions.py
@@ -685,6 +685,15 @@ extensions = [
         docs='http://flask-snow.readthedocs.io/en/latest/',
         github='rbw0/flask-snow'
     ),    
+    Extension('Flask-Dramatiq', 'Étienne Bersac',
+        description='''
+            <p>Plugs <a href="https://dramatiq.io/">Dramatiq</a> task queue in your
+            Flask web app.
+        ''',
+        docs='https://flask-dramatiq.readthedocs.io/',
+        gitlab='https://gitlab.com/bersace/flask-dramatiq',
+        approved=False,
+    ),
 ]
 
 

--- a/flask_website/templates/extensions/index.html
+++ b/flask_website/templates/extensions/index.html
@@ -34,6 +34,10 @@
       <dt>On Github:
       <dd><a href="http://github.com/{{ extension.github }}/">{{ extension.github }}</a>
     {% endif %}
+    {% if extension.gitlab %}
+      <dt>On GitLab:
+      <dd><a href="http://gitlab.com/{{ extension.gitlab }}/">{{ extension.gitlab }}</a>
+    {% endif %}
     {% if extension.bitbucket %}
       <dt>On Bitbucket:
       <dd><a href="http://bitbucket.org/{{ extension.bitbucket }}/">{{ extension.bitbucket }}</a>


### PR DESCRIPTION
Hi,

I'm maintaining [Flask-Dramatiq, an extension to plug [Dramatiq](https://dramatiq.io) task queue and Flask alltogether. I suggest to show it up in Flask Registry.

Flask-Dramatiq is hosted at gitlab.com. Thus, the PR begins with a commit to add `gitlab` metadata alternative for project forge provider.

I would be glad to have Flask-Dramatiq approved. How to apply ? I tried to keep Flask-Dramatiq API and doc consistent with great extension like Flask-SQLAlchemy. I welcome advice and review to approve Flask-Dramatiq :-) Thanks !

## Approval check list

 * [x] requires a maintainer.
 * [x] must provide exactly one package or module named flask_extensionname.
 * [x] must ship a testing suite that can be invoked with make test.
 * APIs of approved extensions will be checked for the following characteristics:
   * [x] support multiple applications running in the same Python process.
   * [x] it must be possible to use the factory pattern for creating applications.
 * [x] The license must be BSD licensed.
 * [x] The naming scheme for official extensions is Flask-ExtensionName or ExtensionName-Flask.
 * [ ] Approved extensions must define all their dependencies in the setup.py file unless a dependency cannot be met because it is not available on PyPI. :bangbang: **Flask-Dramatiq uses poetry.** Source tarball have clean setup.py.
 * [x] The documentation must use the flask theme from the Official Pallets Themes.
 * [ ] The setup.py description (and thus the PyPI description) has to link to the documentation, website (if there is one) and there must be a link to automatically install the development version (PackageName==dev). :bangbang: **not sure about this.**
 * [ ] The zip_safe flag in the setup script must be set to False, even if the extension would be safe for zipping. :bangbang: **poetry does not do this. However, wheel is provided as first class citizen.**
 * [ ] An extension currently has to support Python 3.4 and newer and 2.7. :bangbang: **Dramatiq is limited to Python 3.5. Is 2.7 still relevant ?**
